### PR TITLE
WSB fixes (Windows SandBox)

### DIFF
--- a/Sources/Winget-Install-GUI.ps1
+++ b/Sources/Winget-Install-GUI.ps1
@@ -676,8 +676,15 @@ $Script:stream = [System.IO.MemoryStream]::new($IconBase64, 0, $IconBase64.Lengt
 #Check if WiGui is uptodate
 Get-WiGuiLatestVersion
 
-#Check if Winget is installed, and install if not
-Get-WingetStatus
+#Check if Winget is installed, and install if not (not in WSB!)
+$WhoAmI = & whoami
+if ($WhoAmI -eq 'nt authority\system' -or $WhoAmI -like '*wdagutilityaccount') {
+    Write-Host "You are System or running as Admin in WSB (and can't install this)!"
+    Write-Host "Install WAU via WiGui, please.. ..and then as System search for and install apps in WiGui"
+}
+else {
+    Get-WingetStatus
+}
 
 #Run WiGui
 Get-InstallGUI


### PR DESCRIPTION
The admin user has no rights to the machine winget..
..and as System you can't run the installations under Get-WingetStatus.
You'll have to install WAU (as admin or system) via WiGui and then search and install apps as System in WiGui.
As I do via [NirSoft AdvancedRun](https://www.nirsoft.net/utils/advanced_run.html)